### PR TITLE
fixes #23 theme/index.md 和訳しました。

### DIFF
--- a/theme/index.md
+++ b/theme/index.md
@@ -16,7 +16,7 @@ WordPress テーマ開発者向けハンドブックは、WordPress のテーマ
 <!-- 
 In this handbook, you can learn how to build **block themes or classic themes.**
  -->
-このハンドブックでは、*ブロックテーマやクラシックテーマ** の構築のしかたを学習できます。
+このハンドブックでは、**ブロックテーマやクラシックテーマ** の構築のしかたを学習できます。
 
 <!-- 
 *   A block theme is a new theme that you can use from WordPress version 5.9. It is built mainly using HTML and a theme configuration file. The block theme is composed entirely of blocks, allowing you to edit all parts of your site in the Site Editor.

--- a/theme/index.md
+++ b/theme/index.md
@@ -1,40 +1,55 @@
 <!--
 # Theme Handbook
 -->
-
 # テーマハンドブック
 
 <!--
 *Welcome to the WordPress Theme Developer Handbook, your resource for learning all about the exciting world of WordPress themes.*
 -->
-
-興味深い WordPress テーマのすべてを学ぶための WordPress テーマ開発者向けハンドブックへようこそ。
+*興味深い WordPress テーマのすべてを学ぶための WordPress テーマ開発者向けハンドブックへようこそ。*
 
 <!--
 The Theme Developer Handbook is a repository for all things WordPress themes. Whether you’re new to WordPress themes, or you’re an experienced theme developer, you should be able to find the answer to many of your theme-related questions right here.
 -->
-
 WordPress テーマ開発者向けハンドブックは、WordPress のテーマに関するあらゆる情報を掲載しています。ここでは WordPress テーマを初めてご利用になられる方も経験豊富なテーマ開発者もテーマに関する多くの疑問の答えを探すことができるでしょう。
 
+<!-- 
 In this handbook, you can learn how to build **block themes or classic themes.**
+ -->
+このハンドブックでは、*ブロックテーマやクラシックテーマ** の構築のしかたを学習できます。
 
+<!-- 
 *   A block theme is a new theme that you can use from WordPress version 5.9. It is built mainly using HTML and a theme configuration file. The block theme is composed entirely of blocks, allowing you to edit all parts of your site in the Site Editor.
 *   A classic theme is the original theme, without version limitations, that primarily uses PHP, JavaScript and CSS. Classic themes take advantage of WordPress PHP functions, hooks and filters.
+ -->
+*   ブロックテーマは、WordPress 5.9から使用できる新しいテーマです。主に HTML とテーマ設定ファイルを使って構築されます。ブロックテーマは、完全にブロックで構成されており、サイトエディターでサイトのすべての部分を編集できます。
+*   クラシックテーマは、バージョン制限のないオリジナルのテーマで、主に PHP、JavaScript、CSS を使用します。クラシックテーマは、WordPress の PHP 関数、フック、フィルターを活用します。
 
+<!-- 
 1.  If you’re new to developing WordPress themes, start with section 1, where you can [find out what a theme is](https://developer.wordpress.org/theme/getting-started/what-is-a-theme/), learn about [WordPress’ license](https://developer.wordpress.org/theme/getting-started/wordpress-licensing-the-gpl/), and [set up your development environment](https://developer.wordpress.org/theme/getting-started/setting-up-a-development-environment/).
 2.  Once you’re through the introduction, continue with the [Theme Basics](https://developer.wordpress.org/theme/basics/) section.
+ -->
+1.  WordPress テーマの開発が初めての方は、セクション1から始めましょう。ここでは、[テーマとは何か](https://developer.wordpress.org/theme/getting-started/what-is-a-theme/)を知り、[WordPressのライセンス](https://developer.wordpress.org/theme/getting-started/wordpress-licensing-the-gpl/)について学び、[開発環境のセットアップ](https://developer.wordpress.org/theme/getting-started/setting-up-a-development-environment/)ができます。
+2.  入門編が終わったら、[テーマの基本](https://developer.wordpress.org/theme/basics/)セクションに進みます。
 
-It is recommended to read through both the block theme section and the classic theme sections.
-This will give you an understanding of the differences between the two types of themes, and help you choose what type of theme to build.
+<!-- 
+It is recommended to read through both the block theme section and the classic theme sections. This will give you an understanding of the differences between the two types of themes, and help you choose what type of theme to build.
+ -->
+ブロックテーマのセクションとクラシックテーマのセクションの両方に目を通すことをおすすめします。そうすることで、2種類のテーマの違いを理解でき、どのタイプのテーマを構築するかを選択するのに役立ちます。
 
+<!-- 
 If you’ve got to grips with the basics of themes, check out the [Advanced Theme Topics](https://developer.wordpress.org/theme/advanced-topics/) to learn about child themes, best UI practices, theme testing and more.
+ -->
+テーマの基本を理解したなら、[上級者向けテーマ・トピック](https://developer.wordpress.org/theme/advanced-topics/)をチェックして、子テーマ、ベスト UI プラクティス、テーマのテストなどについて学びましょう。
 
+<!-- 
 Once you’ve got your theme ready for the world, the final section will cover [releasing your theme](https://developer.wordpress.org/themes/releasing-your-theme/), teaching you some best practices for theme distribution, and for getting it ready for the WordPress.org theme directory.
+ -->
+テーマを世に送り出す準備ができたら、最後のセクションでは[あなたのテーマのリリース](https://developer.wordpress.org/themes/releasing-your-theme/)を取り上げ、テーマ配布のベストプラクティスと WordPress.org のテーマディレクトリに登録するための準備を教えます。
 
 * * *
 
 <!--
 The WordPress Theme Developer Handbook is created by the WordPress community, for the WordPress community. We are always looking for more contributors; if you’re interested stop by the [docs team blog](https://make.wordpress.org/docs) to find out more about getting involved.
 -->
-
-この WordPress テーマ開発者向けハンドブックは、WordPress のコミュニティによって、WordPress のコミュニティのために作成されています。いつでも貢献者を募集しておりますので、興味のある方は、[ドキュメントチームブログ](https://make.wordpress.org/docs)をご覧ください。
+この WordPress テーマ開発者向けハンドブックは、WordPress のコミュニティによって、WordPress のコミュニティのために作成されています。いつでも貢献者を募集していますので、興味のある方は、[ドキュメントチームブログ](https://make.wordpress.org/docs)をご覧ください。


### PR DESCRIPTION
※既訳部分に関しても、textlintによる物言いがついた箇所に対して、対応しました。

textlintで多少警告が残ってますが、誤検出と判断しました。
※19行目：「しかた」に対して、「し方」に修正する様、エラー。　（無限ループ）
※32行目：「セクション1」に対して、「セクションゼロ」に修正する様、エラー。
※55行目：「興味のある方」に対して、「興味のあるほう」に修正する様、エラー。

作業用リモートリポジトリ（main）
![image](https://github.com/user-attachments/assets/cf9863a3-4c4f-4303-95b0-2e1bfb14b5bb)

そこからブランチ
![image](https://github.com/user-attachments/assets/dd737781-5d38-4aa2-a15c-dfcceb9cc34c)
※こちらに和訳ファイルを格納しました。