### PR TITLE
fixes #25 theme/credits/feedback.md 和訳しました。

### DIFF
--- a/theme/credits/feedback.md
+++ b/theme/credits/feedback.md
@@ -1,12 +1,33 @@
+<!-- 
 # Feedback
+ -->
+# フィードバック
 
+<!-- 
 ## Giving Feedback
+ -->
+## フィードバックを行う
 
+<!-- 
 We welcome suggestions to improve the article, whether it is to add new topics or to rectify mistakes, you’re invited to help.
+ -->
+新しいトピックの追加や間違いの修正など、記事を改善するための提案を歓迎します。ぜひご協力お願いします。
 
+<!-- 
 You can do so in the following ways
+ -->
+そのためには、以下の方法があります:
 
+<!-- 
 *   Connect to [Slack](https://make.wordpress.org/chat/) and join [#docs](https://wordpress.slack.com/messages/docs/) and make your suggestion there, one of the Documentation Team members will help
 *   Join the [Documentation Team](https://make.wordpress.org/docs/) as an editor and edit away!
+*   Open a ticket in the [Documentation Issue Tracker repository](https://github.com/WordPress/Documentation-Issue-Tracker) on GitHub with the [“themes” label](https://github.com/WordPress/Documentation-Issue-Tracker/labels/themes).
+ -->
+*   [Slack](https://make.wordpress.org/chat/) に接続し、[#docs](https://wordpress.slack.com/messages/docs/) に参加して、そこで提案すれば、ドキュメンテーションチーム・メンバーの誰かが助けてくれるでしょう。
+*   [ドキュメンテーションチーム](https://make.wordpress.org/docs/)に編集者として参加し、編集する !
+*   GitHub の [Documentation Issue Tracker リポジトリ](https://github.com/WordPress/Documentation-Issue-Tracker) に[「themes」ラベル](https://github.com/WordPress/Documentation-Issue-Tracker/labels/themes)を付けて、チケットをオープンする。
 
+<!-- 
 In-page feedback forms are currently planned for the handbooks.
+ -->
+現在のところ、ハンドブック用に、ページ内フィードバック・フォームが計画されています。

--- a/theme/credits/feedback.md
+++ b/theme/credits/feedback.md
@@ -24,8 +24,8 @@ You can do so in the following ways
 *   Open a ticket in the [Documentation Issue Tracker repository](https://github.com/WordPress/Documentation-Issue-Tracker) on GitHub with the [“themes” label](https://github.com/WordPress/Documentation-Issue-Tracker/labels/themes).
  -->
 *   [Slack](https://make.wordpress.org/chat/) に接続し、[#docs](https://wordpress.slack.com/messages/docs/) に参加して、そこで提案すれば、ドキュメンテーションチーム・メンバーの誰かが助けてくれるでしょう。
-*   [ドキュメンテーションチーム](https://make.wordpress.org/docs/)に編集者として参加し、編集する !
-*   GitHub の [Documentation Issue Tracker リポジトリ](https://github.com/WordPress/Documentation-Issue-Tracker) に[「themes」ラベル](https://github.com/WordPress/Documentation-Issue-Tracker/labels/themes)を付けて、チケットをオープンする。
+*   [ドキュメンテーションチーム](https://make.wordpress.org/docs/)に編集者として参加し、編集しましょう !
+*   GitHub の [Documentation Issue Tracker リポジトリ](https://github.com/WordPress/Documentation-Issue-Tracker) に[「themes」ラベル](https://github.com/WordPress/Documentation-Issue-Tracker/labels/themes)を付けて、チケットをオープンします。
 
 <!-- 
 In-page feedback forms are currently planned for the handbooks.


### PR DESCRIPTION
※原文（June 5, 2024版）を反映。

textlintチェック結果：エラーなし

作業用リモートリポジトリ（main）
![image](https://github.com/user-attachments/assets/5184a8be-53e7-4df9-93d2-d45276c09e1a)

そこからブランチ
![image](https://github.com/user-attachments/assets/662d9ee0-b032-427b-8ed8-fe82221c65d1)
※こちらに和訳ファイルを格納しました。