### PR TITLE
fixes #33 theme/getting-started/reading-this-handbook.md 和訳しました。

### DIFF
--- a/theme/getting-started/reading-this-handbook.md
+++ b/theme/getting-started/reading-this-handbook.md
@@ -1,0 +1,253 @@
+<!-- 
+# Reading This Handbook
+ -->
+# このハンドブックを読む
+
+<!-- 
+The goal of this handbook is to walk you through the basics of modern WordPress theme development in its early chapters. Then, work through more advanced topics with each chapter that follows. 
+ -->
+このハンドブックのゴールは、序章で最新の WordPress テーマ開発の基本を案内することです。その後、続く各章でより高度なトピックに取り組みます。
+
+<!-- 
+The quickest way to learn theme development is to simply read this handbook from beginning to end and follow along with its examples.
+ -->
+テーマ開発を学ぶ最も手っ取り早い方法は、このハンドブックを最初から最後まで通して読み、その例に沿って作業を進めていくだけです。
+
+<!-- 
+## Requirements
+ -->
+## 必要条件
+
+<!-- 
+The biggest requirement for building a WordPress theme is a willingness to learn. You are here reading this handbook, so let’s check that one off the list of requirements.
+ -->
+WordPress テーマを構築するための最大の条件は、学ぶ意欲です。あなたはここでこのハンドブックを読んでいるのですから、その1つを必要条件リストから外しましょう。
+
+<!-- 
+WordPress theming has changed many times over the years. Today, the pathway for creating one is much lower than it was in the past. You can absolutely create a theme with no coding knowledge. But you will find it much easier to familiarize yourself with a few web languages. 
+ -->
+WordPress のテーマ設定は、ここ数年の間に何度も変化してきました。今日では、テーマを作成するための敷居は昔よりずっと低くなっています。コーディングの知識がなくてもテーマを作成することは、もちろん可能です。しかし、いくつかの Web 言語に習熟するほうがはるかに簡単なことが分かるでしょう。
+
+<!-- 
+You will see HTML, CSS, PHP, JSON, and JavaScript within the handbook, so it helps to be able to easily recognize what language you are looking at. HTML and CSS are foundational pieces of the web, so those should be prioritized over others. 
+ -->
+このハンドブックには、HTML、CSS、PHP、JSON、JavaScript が掲載されているので、自分が見ているのがどの言語なのかを簡単に認識できます。HTML と CSS は Web の基礎となる部分ですので、他よりも優先されるべきでしょう。
+
+<!-- 
+The following are external resources that you can use to learn more, but there are 1,000s of guides and tutorials around the web:
+ -->
+以下は、あなたがより多くを学ぶために使用できる外部リソースですが、Web 上には1, 000ものガイドやチュートリアルがあります:
+
+<!-- 
+*   [MDN Web Docs: HTML](https://developer.mozilla.org/en-US/docs/Web/HTML)
+*   [MDN Web Docs: CSS](https://developer.mozilla.org/en-US/docs/Web/CSS)
+*   [PHP official documentation](https://www.php.net/docs.php)
+*   [MDN Web Docs: JSON](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/JSON)
+*   [MDN Web Docs: JavaScript](https://developer.mozilla.org/en-US/docs/Learn/JavaScript)
+ -->
+*   [MDN Web ドキュメント: HTML](https://developer.mozilla.org/en-US/docs/Web/HTML)
+*   [MDN Web ドキュメント: CSS](https://developer.mozilla.org/en-US/docs/Web/CSS)
+*   [PHP 公式ドキュメント](https://www.php.net/docs.php)
+*   [MDN Web ドキュメント: JSON](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/JSON)
+*   [MDN Web ドキュメント: JavaScript](https://developer.mozilla.org/en-US/docs/Learn/JavaScript)
+
+<!-- 
+You can get pretty far into theme building via the WordPress user interface, at least by modifying and exporting an existing block theme. But you’ll want to pick up a few more skills to build more advanced features, or to truly create a theme from scratch.
+ -->
+WordPress のユーザーインターフェイスを使って、既存のブロックテーマを修正したりエクスポートしたりすることで、テーマ構築のかなり奥深いところまでたどり着けます。しかし、より高度な機能を構築したり、本当にゼロからテーマを作成したりするには、もう少しスキルを習得したいところでしょう。
+
+<!-- 
+## Your next steps
+ -->
+## 次のステップ
+
+<!-- 
+### For newcomers
+ -->
+### 初めての方の為には
+
+<!-- 
+It is time to truly embark on your journey into learning theme development. It is an exciting moment, so get ready for an adventure.
+ -->
+テーマ開発を学ぶ旅に、本当の意味で乗り出すときが来ました。エキサイティングな瞬間ですから、冒険の準備をしましょう。
+
+<!-- 
+**Setting things up:** if this is your first time building a theme, or if you just want a refresher on the basics of theme development, your next stop should be the [Tools and Setup](https://developer.wordpress.org/themes/getting-started/tools-and-setup/) page. This will help you set up your development environment and determine which tools you need to start off on the right foot.
+ -->
+**セットアップする:** 初めてテーマを構築する場合や、テーマ開発の基本をおさらいしたい場合は、次のステップとして[ツールとセットアップ](https://developer.wordpress.org/themes/getting-started/tools-and-setup/)ページをご覧ください。これは、あなたの開発環境を設定し、正しいスタートを切るために必要なツールを決定するのに役立ちます。
+
+<!-- 
+**Getting off to a quick start:** once you’re set up, check out the [Quick-start guide](https://developer.wordpress.org/themes/getting-started/quick-start-guide/), which is aimed at giving you a taste of what’s to come. It will walk you through setting up a theme to work with.
+ -->
+**スタートダッシュを切る:** セットアップが完了したら、これから始まることを体験していただくことを目的とした、[クイック・スタートガイド](https://developer.wordpress.org/themes/getting-started/quick-start-guide/)をご覧ください。これは、作業するテーマを設定する手順を案内します。
+
+<!-- 
+**Understanding the basics:** once you have everything set up and running, move onto the [Core Concepts](https://developer.wordpress.org/themes/core-concepts/) chapter. There, you will learn the foundational principles behind creating WordPress themes.
+ -->
+**基本を理解する:** すべてのセットアップと実行が完了したら、[コア・コンセプト](https://developer.wordpress.org/themes/core-concepts/)の章に進みます。そこでは、WordPress テーマ作成における基本原則を学びます。
+
+<!-- 
+Afterward, just keep working through each chapter of the handbook.
+ -->
+その後は、ハンドブックの各章を通して作業を続けるだけです。
+
+<!-- 
+### For seasoned theme authors
+ -->
+### 熟練のテーマ作者の為には
+
+<!-- 
+Even if you’ve been creating themes for years, it never hurts to give the full handbook a reading from time to time. It is regularly updated, so there may be new content that you haven’t seen before.
+ -->
+何年もテーマを作成している人でも、時々ハンドブックの全文を読んでみても損はありません。定期的に更新されているので、見たことのない新しいコンテンツがあるかもしれません。
+
+<!-- 
+Feel free to hop around to find the specific topic you need using the handbook’s navigation links. Whatever the case, the Theme Handbook is here to help you discover a solution.
+ -->
+ハンドブックのナビゲーションリンクを使って、ご自由に必要な特定のトピックを見つけてご覧ください。どのような場合でも、テーマ・ハンドブックが解決策を見つけるお手伝いをします。
+
+<!-- 
+*Feeling pretty hardcore?* Jump over to the [Advanced Topics](https://developer.wordpress.org/themes/advanced-topics/) chapter. 
+ -->
+*かなり硬派な感じですか?* [上級者向けトピック](https://developer.wordpress.org/themes/advanced-topics/)の章に飛んでください。
+
+<!-- 
+*Can’t remember the naming format for a particular template?* Find it in the [Template Hierarchy](https://developer.wordpress.org/themes/templates/template-hierarchy/) docs.
+ -->
+*個別のテンプレートの命名フォーマットを覚えていませんか ?* [テンプレートの序列](https://developer.wordpress.org/themes/templates/template-hierarchy/)のドキュメントで見つけてください。
+
+<!-- 
+*Need to brush up on `theme.json`?* No problem. Check out the [Global Settings and Styles](https://developer.wordpress.org/themes/global-settings-and-styles/) documentation. 
+ -->
+*`theme.json` のブラッシュアップが必要ですか ?* 問題ありません。[グローバル設定とスタイル](https://developer.wordpress.org/themes/global-settings-and-styles/)ドキュメントをチェックしてください。
+
+<!-- 
+You can also find theming tutorials and walk-throughs under the [Themes category](https://developer.wordpress.org/news/category/themes/) on the WordPress Developer blog if you can’t find the topic you’re looking for in the handbook.
+ -->
+ハンドブックでお探しのトピックが見つからない場合は、WordPress 開発者ブログの[テーマ・カテゴリー](https://developer.wordpress.org/news/category/themes/)で、テーマ設定のチュートリアルやウォークスルーを見つけることもできます。
+
+<!-- 
+### For classic themes documentation
+ -->
+### クラシック・テーマのドキュメントの為には
+
+<!-- 
+While some of the content in most chapters will apply to classic themes, the docs are primarily geared toward modern block theming. However, there is a dedicated [Classic Themes](https://developer.wordpress.org/themes/classic-themes/) chapter if you need to locate documentation on a specific classic feature.
+ -->
+ほとんどの章にある内容のいくつかは、クラシック・テーマにも適用できますが、ドキュメントは主に最新のブロック・テーマ向けです。しかしながら、特定の クラシック機能に関するドキュメントを探す必要がある場合は、専用の[クラシック・テーマ](https://developer.wordpress.org/themes/classic-themes/)の章があります。
+
+<!-- 
+## How to read code examples
+ -->
+## コード例の読み方
+
+<!-- 
+Throughout the handbook, you will see code examples, and this section is aimed at helping you understand how to read them.
+ -->
+ハンドブック全体を通して、あなたはコード例を見るでしょう。そして、このセクションは、あなたがそれらを読む方法を理解するのを、助けることを目的としています。
+
+<!-- 
+The handbook will use a consistent “namespace” or “prefix” throughout its pages, generally seen as `theme_slug` or `theme-slug`.  This namespace is meant to be replaced in your theme with one that is unique to it. 
+ -->
+ハンドブックでは、ページ全体で一貫した「名前空間」または「接頭辞」を使用し、一般的に `theme_slug` または `theme-slug` が使用されます。この名前空間は、あなたのテーマ独自のものに置き換えることを意味します。
+
+<!-- 
+*But how do you know what your namespace is?* The most straightforward way is to use your theme’s name. If your theme is titled **Fabled Sunset**, you would convert it to the appropriate format for the use case. For example, it would become `fabled_sunset` when used in a PHP function name or `fabled-sunset` as a handle/slug/ID.
+ -->
+*しかし、あなたの名前空間が何であるか、どうやって知ることができますか ?* 最も簡単な方法は、あなたのテーマの名前を使うことです。あなたのテーマのタイトルが **Fabled Sunset** であれば、使用例に適したフォーマットに変換します。たとえば、PHP の関数名として使用する場合は `fabled_sunset` となり、ハンドル/スラグ/ID として使用する場合は `fabled-sunset` となります。
+
+<!-- 
+The practice of “namespacing” code is decades old. Essentially, a namespace is an identifier for a group of objects created so that they do not conflict with objects in other namespaces.
+ -->
+コードに「名前空間」を設定する習慣は、何十年も前から定着しています。基本的に、名前空間とは、他の名前空間のオブジェクトと衝突しないように作成されたオブジェクト・グループの識別子です。
+
+<!-- 
+WordPress has a vast ecosystem of plugins and themes. Each needs a way to distinguish itself from the others. Without unique namespaces, it would get a bit chaotic and errors would arise. 
+ -->
+WordPress には、膨大な数のプラグインとテーマのエコシステムがあります。それぞれを他と区別する方法が不可欠です。一意な名前空間がなければ、少々混沌とし、エラーが発生することになるでしょう。
+
+<!-- 
+For example, if your theme declared a custom function named `get_post()` instead of `fabled_sunset_get_post()`, your site would fail with a fatal error because WordPress already has a function with this name:
+ -->
+たとえば、あなたのテーマが `fabled_sunset_get_post()` の代わりに `get_post()` という名前のカスタム関数を宣言した場合、WordPress にはすでにこの名前の関数があるので、あなたのサイトは致命的なエラーで失敗するでしょう:
+
+<!-- 
+[![Screenshot of an error message stating that you cannot redeclare the get_post() function, which was already declared.](https://i0.wp.com/developer.wordpress.org/files/2023/11/fatal-error.jpg?resize=1760%2C824&ssl=1)](https://i0.wp.com/developer.wordpress.org/files/2023/11/fatal-error.jpg?ssl=1)
+ -->
+[![すでに宣言されている get_post() 関数を再宣言できないという、エラーメッセージのスクリーンショット。](https://i0.wp.com/developer.wordpress.org/files/2023/11/fatal-error.jpg?resize=1760%2C824&ssl=1)](https://i0.wp.com/developer.wordpress.org/files/2023/11/fatal-error.jpg?ssl=1)
+
+<!-- 
+Avoiding these types of errors is the primary reason the handbook will include namespaced or prefixed code examples.
+ -->
+この種のエラーを避けることが、ハンドブックに名前空間または接頭辞付きのコード例を含める主な理由です。
+
+<!-- 
+### Namespacing examples
+ -->
+### 名前空間の例
+
+<!-- 
+Using the fictional theme name **Fabled Sunset**, let’s look at some examples of formatting your namespace. Don’t worry if you don’t understand these yet or if you do not know anything about code. This is only meant to help you read the handbook.
+ -->
+架空のテーマ名 **Fabled Sunset** を使って、名前空間のフォーマット例を見てみましょう。まだ理解できなくても、コードのことを知らなくても、心配しないでください。これは、ハンドブックを読む手助けをするためだけのものです。
+
+<!-- 
+**Usage in script and style handles:**
+ -->
+**スクリプト・ハンドルおよびスタイル・ハンドルでの使用例:**
+
+```php
+<?php
+// theme-slug-editor becomes:
+wp_enqueue_script( 'fabled-sunset-editor', ... );
+
+// theme-slug-main becomes:
+wp_enqueue_style( 'fabled-sunset-main', ... );
+```
+
+<!-- 
+**Usage in text domains (used for translations):**
+ -->
+**テキストドメインでの使用例 (翻訳に使用):**
+
+```php
+<?php
+// theme-slug becomes:
+esc_html_e( 'Hello, world!', 'fabled-sunset' );
+```
+
+<!-- 
+**Usage in PHP Functions:**
+ -->
+**PHP 関数での使用例:**
+
+```php
+<?php
+// theme_slug_func() becomes:
+function fabled_sunset_func() {
+	// ...
+}
+```
+
+<!-- 
+**Usage in PHP classes:**
+ -->
+**PHP クラスでの使用例:**
+
+```php
+<?php
+// Theme_Slug_Class() becomes:
+class Fabled_Sunset_Class() {
+	// ...
+}
+```
+
+<!-- 
+As you read through the handbook, you will learn when to use each case. For now, just know that you should always replace the example namespace with one that is unique to your project.
+ -->
+このハンドブックを読み進めるうちに、各ケースをどのような場合に使用すれば良いかがわかってきます。今のところは、例の名前空間を常に自分のプロジェクト独自のものに置き換えるべきだ、ということだけ知っておいてください。
+
+<!-- 
+The WordPress Coding Standards [encourages the use of PHP’s built-in namespaces](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#namespace-declarations). The same guideline would apply: use your theme’s name to create your namespace. In this case, the namespace for the example theme would be `Fabled_Sunset` or `FabledSunset`. The Theme Handbook uses a prefixed style for PHP function and class names, as shown above. This is primarily because it is simpler for showing one-off code examples.
+ -->
+WordPress コーディング標準では、[PHP 内蔵の名前空間の使用を推奨](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#namespace-declarations)しています。同じガイドラインが適用されます: あなたのテーマの名前を使って名前空間を作成してください。この場合、例のテーマの名前空間は `Fabled_Sunset` または `FabledSunset` となります。テーマハンドブックでは、上記のように、PHP の関数名とクラス名に接頭辞をつけるスタイルを採用しています。


### PR DESCRIPTION
Fixes #33 

textlintチェック結果：エラーなし

作業用リモートリポジトリ（main）
![image](https://github.com/user-attachments/assets/a2b7af1b-91cf-427d-8af4-4e287f29b757)

そこからブランチ
2024-12-01 23:25時点の原文を反映。
![image](https://github.com/user-attachments/assets/3fbcf840-2488-4d05-8ed2-84bc961108b6)
※こちらに和訳ファイルを格納しました。