### PR TITLE
theme/advanced-topics/child-themes.md 和訳しました。

### DIFF
--- a/theme/advanced-topics/child-themes.md
+++ b/theme/advanced-topics/child-themes.md
@@ -130,7 +130,7 @@ Outside of that, there is no standard method of creating an installable grandchi
 Let’s try creating a child theme of the default [Twenty Twenty-Four](https://wordpress.org/themes/twentytwentyfour/) theme bundled with WordPress. 
  -->
 
-WordPress にバンドルされているデフォルト・テーマ [Twenty Twenty-Four](https://wordpress.org/themes/twentytwentyfour/) を作成してみましょう。
+WordPress にバンドルされているデフォルト・テーマ [Twenty Twenty-Four](https://wordpress.org/themes/twentytwentyfour/) の子テーマを作成してみましょう。
 
 <!-- 
 ### Create a child theme folder


### PR DESCRIPTION
Fixes #108

「孫テーマについては ?」項の、下記について、textlintは「レイヤーではなくレイヤに変えろ」と警告してます。
* それらはテーマ・レイヤーの一部ではないだけ
* ユーザー・カスタマイズ・レイヤーは

内閣告示「外来語の表記」（平成3年内閣告示第2号）では、原則として長音符「ー」を用いると定められているが、慣用に応じて省ける、とも記載されています。